### PR TITLE
Update wat2wasm parameters

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,7 +1,7 @@
 { compiler ? "ghc882"
 
-, rev    ? "c667aba79ce4fd8fe0922024e0cb2826daf6a7c5"
-, sha256 ? "03w6sxmr2am57m3hjzlzii73xrgkpvv1q9bg7y5nlnid21bp1fza"
+, rev    ? "1480c1a7b5628741e5d87b53e34ed123286dfc5a"
+, sha256 ? "19ahkbf4kvp7jd781dixiwydbyqmhqjim0rgq6zgyr5ac3wcigm0"
 
 , pkgs   ?
     if builtins.compareVersions builtins.nixVersion "2.0" < 0

--- a/test/Wat2Wasm.hs
+++ b/test/Wat2Wasm.hs
@@ -13,7 +13,7 @@ wat2Wasm contents = do
   wasm <- emptyTempFile "." "test.wasm"
   writeFile wat contents
   (exit, _out, err) <-
-    readProcessWithExitCode "wat2wasm" ["--enable-multi-value", "--enable-sign-extension", wat, "-o", wasm] ""
+    readProcessWithExitCode "wat2wasm" [wat, "-o", wasm] ""
   case exit of
     ExitSuccess   -> do
       res <- BL.readFile wasm


### PR DESCRIPTION
--enable-multi-value and --enable-sign-extension are on by default now,
so remove those.