### PR TITLE
Remove unused region in initialize module arg

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -128,7 +128,7 @@ main = do
     Left  err    -> fail $ show err
     Right values -> do
       bytes <- Lazy.readFile wasm
-      let ast = Identity $ runGet getModule bytes
+      let ast = runGet getModule bytes
       result <- runExceptT $ do
         let names = singleton "Main" 1
             mods  = IntMap.singleton 1 app

--- a/src/Wasm/Exec/Eval.hs
+++ b/src/Wasm/Exec/Eval.hs
@@ -852,11 +852,11 @@ resolveImports names mods inst = flip execStateT inst $
               put m'
 
 initialize :: (Regioned f, Show1 f, PrimMonad m)
-           => f (Module f)
+           => Module f
            -> Map Text ModuleRef
            -> IntMap (ModuleInst f m)
            -> EvalT m (ModuleRef, ModuleInst f m)
-initialize (value -> mod) names mods = do
+initialize mod names mods = do
   inst <- resolveImports names mods (emptyModuleInst mod)
   let ref = nextKey mods
   inst' <- flip execStateT inst $ do
@@ -887,25 +887,25 @@ initialize (value -> mod) names mods = do
   pure (ref, inst')
 
 {-# SPECIALIZE initialize
-           :: Identity (Module Identity)
+           :: Module Identity
            -> Map Text ModuleRef
            -> IntMap (ModuleInst Identity IO)
            -> EvalT IO (ModuleRef, ModuleInst Identity IO) #-}
 
 {-# SPECIALIZE initialize
-           :: Identity (Module Identity)
+           :: Module Identity
            -> Map Text ModuleRef
            -> IntMap (ModuleInst Identity (ST s))
            -> EvalT (ST s) (ModuleRef, ModuleInst Identity (ST s)) #-}
 
 {-# SPECIALIZE initialize
-           :: Phrase (Module Phrase)
+           :: Module Phrase
            -> Map Text ModuleRef
            -> IntMap (ModuleInst Phrase IO)
            -> EvalT IO (ModuleRef, ModuleInst Phrase IO) #-}
 
 {-# SPECIALIZE initialize
-           :: Phrase (Module Phrase)
+           :: Module Phrase
            -> Map Text ModuleRef
            -> IntMap (ModuleInst Phrase (ST s))
            -> EvalT (ST s) (ModuleRef, ModuleInst Phrase (ST s)) #-}

--- a/src/Wasm/Text/Winter.hs
+++ b/src/Wasm/Text/Winter.hs
@@ -11,7 +11,6 @@ module Wasm.Text.Winter where
 import           Control.Monad.Except
 import           Control.Monad.Primitive
 import           Data.Binary.Get
-import           Data.Default.Class (Default(..))
 import           Data.Functor.Classes
 
 import           Wasm.Text.Wast
@@ -38,7 +37,7 @@ instance (PrimMonad m, Regioned f, Decode.Decodable f, Show1 f)
   decodeModule = Right . runGet Decode.getModule
   initializeModule m names mods =
     fmap (either (Left . show) Right)
-      $ runExceptT $ Eval.initialize (m @@ def) names mods
+      $ runExceptT $ Eval.initialize m names mods
 
   invokeByName mods inst name stack =
     fmap (either (Left . show) (Right . (,inst)))


### PR DESCRIPTION
The region of module is never used and was initialized as `def` in the
call sites.