### PR TITLE
Fix floating point operations

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -22,11 +22,11 @@
 
 let
 
-wasm-src = pkgs.fetchFromGitHub {
+spec-tests = pkgs.fetchFromGitHub {
     owner  = "WebAssembly";
-    repo   = "spec";
-    rev    = "opam-1.1.1";
-    sha256 = "1kp72yv4k176i94np0m09g10cviqp2pnpm7jmiq6ik7fmmbknk7c";
+    repo   = "testsuite";
+    rev    = "master";
+    sha256 = "1fwx2lcd8g9c5p3xq954kvhh1ivmfkp7p7f56d6697ydkb178vap";
   };
 
 drv = pkgs.haskellPackages.developPackage {
@@ -52,4 +52,4 @@ drv = pkgs.haskellPackages.developPackage {
   inherit returnShellEnv;
 };
 
-in drv.overrideAttrs(old: { WASM_SPEC_TESTS = "${wasm-src}/test/core"; })
+in drv.overrideAttrs(old: { WASM_SPEC_TESTS = "${spec-tests}"; })

--- a/src/Wasm/Exec/Eval.hs
+++ b/src/Wasm/Exec/Eval.hs
@@ -82,7 +82,7 @@ data EvalError
   | EvalTableError Region Table.TableError
   | EvalExhaustionError Region String
   | EvalNumericError Region NumericError
-  deriving (Show, Eq)
+  deriving (Show)
 
 instance Exception EvalError
 

--- a/src/Wasm/Exec/EvalNumeric.hs
+++ b/src/Wasm/Exec/EvalNumeric.hs
@@ -493,7 +493,11 @@ i32_trunc_sat_s_f64 d
   | otherwise = truncate d
 
 i32_trunc_sat_u_f64 :: Double -> Int32
-i32_trunc_sat_u_f64 = truncate -- FIXME
+i32_trunc_sat_u_f64 d
+  | isNaN d = 0
+  | d <= -1.0 = 0
+  | d >= negate (fromIntegral (minBound :: Int32)) * 2.0 = -1
+  | otherwise = truncate d
 
 i32_reinterpret_f32 :: Float -> Word32
 i32_reinterpret_f32 = floatToBits
@@ -530,7 +534,12 @@ i64_trunc_s_f64 f = do
       Right (truncate f)
 
 i64_trunc_u_f64 :: Double -> Either NumericError Word64
-i64_trunc_u_f64 f = checkNonNaN f >> Right (truncate f)
+i64_trunc_u_f64 f = do
+    checkNonNaN f
+    if f >= negate (fromIntegral (minBound :: Int64) :: Double) * 2.0 || f <= -1.0 then
+      Left NumericIntegerOverflow
+    else
+      Right (truncate f)
 
 i64_trunc_sat_s_f32 :: Float -> Int64
 i64_trunc_sat_s_f32 f
@@ -544,7 +553,7 @@ i64_trunc_sat_u_f32 f
   | isNaN f = 0
   | f <= -1.0 = 0
   | f >= negate (fromIntegral (minBound :: Int64)) * 2.0 = -1
-  | f >= negate (fromIntegral (minBound :: Int64)) = (truncate (f - 9223372036854775808.0)) .|. minBound
+  | f >= negate (fromIntegral (minBound :: Int64)) = round (f - 9223372036854775808.0) .|. minBound
   | otherwise = truncate f
 
 i64_trunc_sat_s_f64 :: Double -> Int64
@@ -555,7 +564,12 @@ i64_trunc_sat_s_f64 d
   | otherwise = truncate d
 
 i64_trunc_sat_u_f64 :: Double -> Int64
-i64_trunc_sat_u_f64 = truncate -- FIXME
+i64_trunc_sat_u_f64 d
+  | isNaN d = 0
+  | d <= -1.0 = 0
+  | d >= negate (fromIntegral (minBound :: Int64)) * 2.0 = -1
+  | d >= negate (fromIntegral (minBound :: Int64)) = round (d - 9223372036854775808.0) .|. minBound
+  | otherwise = truncate d
 
 i64_reinterpret_f64 :: Double -> Word64
 i64_reinterpret_f64 = doubleToBits

--- a/src/Wasm/Exec/EvalNumeric.hs
+++ b/src/Wasm/Exec/EvalNumeric.hs
@@ -318,20 +318,28 @@ class Numeric t => FloatType t where
   fsqrt = sqrt
 
   fceil :: t -> t
-  default fceil :: RealFrac t => t -> t
-  fceil = (fromIntegral :: Integer -> t) . ceiling
+  default fceil :: RealFloat t => t -> t
+  fceil a
+    | isNaN a = 0 / 0 -- NaN
+    | otherwise = (fromIntegral :: Integer -> t) (ceiling a)
 
   ffloor :: t -> t
-  default ffloor :: RealFrac t => t -> t
-  ffloor = (fromIntegral :: Integer -> t) . floor
+  default ffloor :: RealFloat t => t -> t
+  ffloor a
+    | isNaN a = 0 / 0 -- NaN
+    | otherwise = fromIntegral (floor a :: Integer)
 
   ftrunc :: t -> t
-  default ftrunc :: RealFrac t => t -> t
-  ftrunc = (fromIntegral :: Integer -> t) . truncate
+  default ftrunc :: RealFloat t => t -> t
+  ftrunc a
+    | isNaN a = 0 / 0 -- NaN
+    | otherwise = (fromIntegral :: Integer -> t) (truncate a)
 
   fnearest :: t -> t
-  default fnearest :: RealFrac t => t -> t
-  fnearest = (fromIntegral :: Integer -> t) . round
+  default fnearest :: RealFloat t => t -> t
+  fnearest a
+    | isNaN a = 0 / 0 -- NaN
+    | otherwise = (fromIntegral :: Integer -> t) (round a)
 
   floatUnOp :: FloatOp n Unary -> t -> t
   floatUnOp op x = case op of

--- a/src/Wasm/Exec/EvalNumeric.hs
+++ b/src/Wasm/Exec/EvalNumeric.hs
@@ -575,7 +575,7 @@ i64_reinterpret_f64 :: Double -> Word64
 i64_reinterpret_f64 = doubleToBits
 
 f32_demote_f64 :: Double -> Float
-f32_demote_f64 = fromRational . toRational
+f32_demote_f64 = canonicalizeNaN . double2Float
 
 f32_convert_s_i32 :: Int32 -> Float
 f32_convert_s_i32 = fromIntegral
@@ -606,8 +606,8 @@ f32_convert_u_i64 i
 f32_reinterpret_i32 :: Word32 -> Float
 f32_reinterpret_i32 = floatFromBits
 
-f64_promote_f64 :: Float -> Double
-f64_promote_f64 = fromRational . toRational
+f64_promote_f32 :: Float -> Double
+f64_promote_f32 = canonicalizeNaN . float2Double
 
 f64_convert_s_i32 :: Int32 -> Double
 f64_convert_s_i32 = fromIntegral
@@ -765,7 +765,7 @@ instance FloatType Double where
 
   floatCvtOp op = case op of
     DemoteF64      -> error "DemoteF64 on Double has no meaning"
-    PromoteF32     -> fmap (toValue . f64_promote_f64) . fromValue 1
+    PromoteF32     -> fmap (toValue . f64_promote_f32) . fromValue 1
     ConvertSI32    -> fmap (toValue . f64_convert_s_i32) . fromValue 1
     ConvertUI32    -> fmap (toValue . f64_convert_u_i32) . fromValue 1
     ConvertSI64    -> fmap (toValue . f64_convert_s_i64) . fromValue 1

--- a/src/Wasm/Exec/EvalNumeric.hs
+++ b/src/Wasm/Exec/EvalNumeric.hs
@@ -377,8 +377,6 @@ class Numeric t => FloatType t where
   fmax = max
 
   fcopysign :: t -> t -> t
-  default fcopysign :: (Ord t, Num t) => t -> t -> t
-  fcopysign = \x y -> if x < 0 then - (abs y) else abs y
 
   floatBinOp :: FloatOp n Binary -> t -> t -> Either NumericError t
   floatBinOp op x y = case op of
@@ -651,6 +649,12 @@ instance FloatType Float where
     | a > b = a
     | otherwise = 0 / 0 -- NaN
 
+  fcopysign f1 f2 =
+    let val = floatToWord f1 .&. 0x7FFFFFFF -- bits 0..31
+        sign = floatToWord f2 .&. 0x80000000 -- 32th bit
+     in
+        wordToFloat (sign .|. val)
+
 instance FloatType Double where
   floatCvtOp op = case op of
     DemoteF64      -> error "DemoteF64 on Double has no meaning"
@@ -672,3 +676,9 @@ instance FloatType Double where
     | a < b = b
     | a > b = a
     | otherwise = 0 / 0 -- NaN
+
+  fcopysign f1 f2 =
+    let val = doubleToWord f1 .&. 0x7FFFFFFFFFFFFFFF -- bits 0..33
+        sign = doubleToWord f2 .&. 0x8000000000000000 -- 64th bit
+     in
+        wordToDouble (sign .|. val)

--- a/src/Wasm/Exec/EvalNumeric.hs
+++ b/src/Wasm/Exec/EvalNumeric.hs
@@ -584,10 +584,24 @@ f32_convert_u_i32 :: Word32 -> Float
 f32_convert_u_i32 = fromIntegral
 
 f32_convert_s_i64 :: Int64 -> Float
-f32_convert_s_i64 = fromIntegral
+f32_convert_s_i64 i
+  | i /= minBound && abs i < 0x10000000000000 = fromIntegral i
+  | otherwise =
+    let
+      r | i .&. 0xfff == 0 = 0
+        | otherwise = 1
+    in
+      fromIntegral ((i `shiftR` 12) .|. r) * (2 ** 12)
 
 f32_convert_u_i64 :: Word64 -> Float
-f32_convert_u_i64 = fromIntegral
+f32_convert_u_i64 i
+  | i < 0x10000000000000 = fromIntegral i
+  | otherwise =
+    let
+      r | i .&. 0xfff == 0 = 0
+        | otherwise = 1
+    in
+      fromIntegral ((i `shiftR` 12) .|. r) * (2 ** 12)
 
 f32_reinterpret_i32 :: Word32 -> Float
 f32_reinterpret_i32 = floatFromBits
@@ -604,8 +618,12 @@ f64_convert_u_i32 = fromIntegral
 f64_convert_s_i64 :: Int64 -> Double
 f64_convert_s_i64 = fromIntegral
 
-f64_convert_u_i64 :: Word64 -> Double
-f64_convert_u_i64 = fromIntegral
+f64_convert_u_i64 :: Int64 -> Double
+f64_convert_u_i64 i
+  | i >= 0 = fromIntegral i
+  | otherwise =
+    let i' = fromIntegral i :: Word64
+     in fromIntegral ((i' `shiftR` 1) .|. (i' .&. 1)) * 2.0
 
 f64_reinterpret_i64 :: Word64 -> Double
 f64_reinterpret_i64 = doubleFromBits

--- a/src/Wasm/Exec/EvalNumeric.hs
+++ b/src/Wasm/Exec/EvalNumeric.hs
@@ -31,7 +31,7 @@ data NumericError
   = NumericTypeError Int Value ValueType
   | NumericIntegerDivideByZero
   | NumericIntegerOverflow
-  deriving (Show, Eq)
+  deriving (Show)
 
 class Numeric t where
   type OpType t :: * -> *

--- a/src/Wasm/Exec/EvalNumeric.hs
+++ b/src/Wasm/Exec/EvalNumeric.hs
@@ -18,6 +18,9 @@ import Data.Int
 import Data.Word
 import Prelude hiding (lookup, elem)
 
+-- Bitwise conversion between words and floats
+import Data.Binary.IEEE754 (wordToDouble, doubleToWord, wordToFloat, floatToWord)
+
 import Wasm.Runtime.Memory
 import Wasm.Syntax.Ops.Float as F
 import Wasm.Syntax.Ops.Int as I
@@ -622,6 +625,18 @@ instance FloatType Float where
     ConvertUI64    -> fmap (toValue . f32_convert_u_i64) . fromValue 1
     ReinterpretInt -> fmap (toValue . f32_reinterpret_i32) . fromValue 1
 
+  fmin a b
+    | a == b = wordToFloat (floatToWord a .|. floatToWord b)
+    | a < b = a
+    | a > b = b
+    | otherwise = 0 / 0 -- NaN
+
+  fmax a b
+    | a == b = wordToFloat (floatToWord a .|. floatToWord b)
+    | a < b = b
+    | a > b = a
+    | otherwise = 0 / 0 -- NaN
+
 instance FloatType Double where
   floatCvtOp op = case op of
     DemoteF64      -> error "DemoteF64 on Double has no meaning"
@@ -631,3 +646,15 @@ instance FloatType Double where
     ConvertSI64    -> fmap (toValue . f64_convert_s_i64) . fromValue 1
     ConvertUI64    -> fmap (toValue . f64_convert_u_i64) . fromValue 1
     ReinterpretInt -> fmap (toValue . f64_reinterpret_i64) . fromValue 1
+
+  fmin a b
+    | a == b = wordToDouble (doubleToWord a .|. doubleToWord b)
+    | a < b = a
+    | a > b = b
+    | otherwise = 0 / 0 -- NaN
+
+  fmax a b
+    | a == b = wordToDouble (doubleToWord a .|. doubleToWord b)
+    | a < b = b
+    | a > b = a
+    | otherwise = 0 / 0 -- NaN

--- a/src/Wasm/Runtime/Global.hs
+++ b/src/Wasm/Runtime/Global.hs
@@ -20,7 +20,7 @@ data GlobalInst m = GlobalInst
   }
 
 instance Show (GlobalInst m) where
-  showsPrec _d GlobalInst {..} = showString "GlobalInst"
+  showsPrec _d GlobalInst {} = showString "GlobalInst"
 
 makeLenses ''GlobalInst
 

--- a/src/Wasm/Runtime/Memory.hs
+++ b/src/Wasm/Runtime/Memory.hs
@@ -53,7 +53,7 @@ data MemoryInst m = MemoryInst
   }
 
 instance Show (MemoryInst m) where
-  showsPrec _d MemoryInst {..} = showString "MemoryInst"
+  showsPrec _d MemoryInst {} = showString "MemoryInst"
 
 makeLenses ''MemoryInst
 

--- a/src/Wasm/Runtime/Memory.hs
+++ b/src/Wasm/Runtime/Memory.hs
@@ -30,15 +30,12 @@ import           Control.Exception
 import           Control.Monad
 import           Control.Monad.Except
 import           Control.Monad.Primitive
-import           Data.Array.ST (newArray, readArray, MArray, STUArray)
-import           Data.Array.Unsafe (castSTUArray)
 import           Data.Int
 import           Data.Primitive.MutVar
 import           Data.Primitive.ByteArray
 import qualified Data.Primitive.ByteArray.Unaligned    as UABA
 import qualified Data.Primitive.ByteArray.LittleEndian as LEBA
 import           Data.Word
-import           GHC.ST (runST, ST)
 import           Lens.Micro.Platform
 import           Data.ByteString.Lazy (ByteString)
 import qualified Data.ByteString.Lazy as BS
@@ -48,6 +45,7 @@ import           Wasm.Syntax.Memory
 import           Wasm.Syntax.Types
 import           Wasm.Syntax.Values (Value)
 import qualified Wasm.Syntax.Values as Values
+import           Wasm.Util.Float
 
 data MemoryInst m = MemoryInst
   { _miContent :: MutVar (PrimState m) (MutableByteArray (PrimState m))
@@ -267,22 +265,3 @@ importMemory mem bs = do
     let !(SBS ba) = toShort (BS.toStrict bs)
     copyByteArray m' 0 (ByteArray ba) 0 (fromIntegral (BS.length bs))
     writeMutVar (mem^.miContent) m'
-
--- Conversions used in "Wasm.Exec.EvalNumeric"
-
-cast :: (MArray (STUArray s) a (ST s), MArray (STUArray s) b (ST s))
-     => a -> ST s b
-cast x = newArray (0 :: Int, 0) x >>= castSTUArray >>= flip readArray 0
-{-# INLINE cast #-}
-
-floatToBits :: Float -> Int32
-floatToBits x = runST (cast x)
-
-floatFromBits :: Int32 -> Float
-floatFromBits x = runST (cast x)
-
-doubleToBits :: Double -> Int64
-doubleToBits x = runST (cast x)
-
-doubleFromBits :: Int64 -> Double
-doubleFromBits x = runST (cast x)

--- a/src/Wasm/Syntax/Values.hs
+++ b/src/Wasm/Syntax/Values.hs
@@ -16,7 +16,7 @@ data Value
   | I64 {-# UNPACK #-} !Int64
   | F32 {-# UNPACK #-} !Float
   | F64 {-# UNPACK #-} !Double
-  deriving (Eq, Generic, NFData, Ord, Show)
+  deriving (Generic, NFData, Show)
 
 typeOf :: Value -> ValueType
 typeOf = \case

--- a/src/Wasm/Syntax/Values.hs
+++ b/src/Wasm/Syntax/Values.hs
@@ -5,18 +5,21 @@
 module Wasm.Syntax.Values where
 
 import           Control.DeepSeq
+import           Data.Bits (shiftR, (.&.))
 import           Data.Bool
 import           Data.Int
+import           Data.Word
 import           GHC.Generics
 
 import           Wasm.Syntax.Types
+import           Wasm.Util.Float (floatToBits, doubleToBits)
 
 data Value
   = I32 {-# UNPACK #-} !Int32
   | I64 {-# UNPACK #-} !Int64
   | F32 {-# UNPACK #-} !Float
   | F64 {-# UNPACK #-} !Double
-  deriving (Generic, NFData, Show)
+  deriving (Generic, NFData)
 
 typeOf :: Value -> ValueType
 typeOf = \case
@@ -34,3 +37,30 @@ defaultValue = \case
 
 valueOfBool :: Bool -> Value
 valueOfBool = I32 . bool 0 1
+
+instance Show Value where
+  show v = case v of
+    I32 i -> show i ++ "i32"
+    I64 i -> show i ++ "i64"
+    F32 f -> show f ++ "f32 (" ++ showFloatBits f ++ ")"
+    F64 d -> show d ++ "f64 (" ++ showDoubleBits d ++ ")"
+
+showFloatBits :: Float -> String
+showFloatBits = showFBits 8 23 . fromIntegral . floatToBits
+
+showDoubleBits :: Double -> String
+showDoubleBits = showFBits 11 52 . doubleToBits
+
+showFBits :: Word8 -> Word8 -> Word64 -> String
+showFBits exp_digits signi_digits float_bits =
+    show_bits (float_bits `shiftR` fromIntegral (exp_digits + signi_digits)) 1 ++
+    "_" ++
+    reverse (show_bits (float_bits `shiftR` fromIntegral signi_digits) exp_digits) ++
+    "_" ++
+    reverse (show_bits float_bits signi_digits)
+  where
+    show_bits :: Word64 -> Word8 -> String
+    show_bits _ 0 = ""
+    show_bits x n =
+      let bit = if x .&. 1 == 1 then '1' else '0'
+       in bit : show_bits (x `shiftR` 1) (n - 1)

--- a/src/Wasm/Text/Wast.hs
+++ b/src/Wasm/Text/Wast.hs
@@ -299,19 +299,6 @@ expr = do
 
   invoke = keyword "invoke" *> (Invoke <$> string_ <*> many (expr @_ @m))
 
--- | In GHC 0/0 generates NaN with sign bit set (i.e. negative NaN) which is not
--- the canonical NaN specified in the Wasm spec. This is the canonical NaN.
-f32CanonicalNaN :: Float
-f32CanonicalNaN =
-    -- 0b0_11111111_10000000000000000000000
-    floatFromBits 2143289344
-
--- | Like `f32CanonicalNaN` but for F64.
-f64CanonicalNaN :: Double
-f64CanonicalNaN =
-    -- 0b0_11111111111_1000000000000000000000000000000000000000000000000000
-    doubleFromBits 9221120237041090560
-
 setFloatPayload :: Float -> Integer -> Float
 setFloatPayload f p =
     assert (p >= 1 && p <= ((1 `shiftL` 23) - 1)) $

--- a/src/Wasm/Text/Wast.hs
+++ b/src/Wasm/Text/Wast.hs
@@ -34,7 +34,6 @@ import           Control.Monad.Fail (MonadFail)
 import           Control.Monad.Trans.Control
 import           Control.Monad.Trans.State
 import           Data.Bifunctor
-import           Data.Binary.IEEE754 (wordToDouble, doubleToWord, wordToFloat, floatToWord)
 import           Data.Bits (clearBit)
 import           Data.ByteString.Lazy (ByteString)
 import           Data.ByteString.Lazy.Char8 as Byte (pack)
@@ -55,6 +54,8 @@ import           Text.Parsec hiding ((<|>), many, optional,
 import           Text.Parsec.Language (haskellDef)
 import           Text.Parsec.String
 import qualified Text.Parsec.Token as P
+
+import           Wasm.Util.Float
 
 {-
 import           Wasm.Binary.Decode
@@ -280,13 +281,13 @@ expr = do
 -- to positive NaN and "-nan" to negative we normalize parsed values of "nan".
 normalizeFloatNaN :: Float -> Float
 normalizeFloatNaN f
-  | isNaN f = wordToFloat (clearBit (floatToWord f) 31)
+  | isNaN f = floatFromBits (clearBit (floatToBits f) 31)
   | otherwise = f
 
 -- | `normalizeFloatNaN`, but for doubles.
 normalizeDoubleNaN :: Double -> Double
 normalizeDoubleNaN d
-  | isNaN d = wordToDouble (clearBit (doubleToWord d) 63)
+  | isNaN d = doubleFromBits (clearBit (doubleToBits d) 63)
   | otherwise = d
 
 cmd :: forall w m. WasmEngine w m => Parser (Cmd w)

--- a/src/Wasm/Text/Wast.hs
+++ b/src/Wasm/Text/Wast.hs
@@ -204,18 +204,20 @@ expr = do
  where
   constant =  go "i32.const" (const_i32 @w @m) (fromIntegral <$> negOr_ int)
           <|> go "f32.const" (const_f32 @w @m) (negOr_ float32)
-          <|> go "i64.const" (const_i64 @w @m) (negOr_ int)
+          <|> go "i64.const" (const_i64 @w @m) (fromIntegral <$> negOr_ int)
           <|> go "f64.const" (const_f64 @w @m) (negOr_ float64)
    where
+    int :: Parser Integer
     int         = do{ f <- P.lexeme lexer sign
                     ; n <- nat
-                    ; return (f (fromIntegral n))
+                    ; return (f n)
                     }
 
     sign        =   (char '-' >> return negate)
                 <|> (char '+' >> return id)
                 <|> return id
 
+    nat :: Parser Integer
     nat         = zeroNumber <|> decimal
 
     zeroNumber  = do{ _ <- char '0'

--- a/src/Wasm/Text/Wast.hs
+++ b/src/Wasm/Text/Wast.hs
@@ -503,41 +503,6 @@ invokeModule readModule decl k = do
 -- These tests currently do not work.
 ignoredFunctions :: [String]
 ignoredFunctions = [
-  -- float_misc.wast
-  "f32.abs",
-  "f64.abs",
-  "f32.neg",
-  "f64.neg",
-  "f32.copysign",
-  "f64.copysign",
-  "f64.nearest",
-  "f64.sqrt",
-
-  -- float_memory.wast
-  "f32.load",
-  "f64.load",
-
-  -- local_tee.wast
-  "as-unary-operand",
-
-  -- select.wast
-  "select_f32",
-  "select_f64",
-
-  -- address.wast
-  "32_good5",
-  "64_good5",
-
-  -- traps.wast
-  "no_dce.i32.trunc_f32_s",
-  "no_dce.i32.trunc_f32_u",
-  "no_dce.i32.trunc_f64_s",
-  "no_dce.i32.trunc_f64_u",
-  "no_dce.i64.trunc_f32_s",
-  "no_dce.i64.trunc_f32_u",
-  "no_dce.i64.trunc_f64_s",
-  "no_dce.i64.trunc_f64_u",
-
   -- linking.wast
   "get table[0]"
   ]

--- a/src/Wasm/Util/Float.hs
+++ b/src/Wasm/Util/Float.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE FlexibleContexts #-}
+
+module Wasm.Util.Float
+  ( floatToBits
+  , floatFromBits
+  , doubleToBits
+  , doubleFromBits
+  ) where
+
+import Data.Array.ST (newArray, readArray, MArray, STUArray)
+import Data.Array.Unsafe (castSTUArray)
+import Data.Word
+import GHC.ST (runST, ST)
+
+cast :: (MArray (STUArray s) a (ST s), MArray (STUArray s) b (ST s))
+     => a -> ST s b
+cast x = newArray (0 :: Int, 0) x >>= castSTUArray >>= flip readArray 0
+
+floatToBits :: Float -> Word32
+floatToBits x = runST (cast x)
+
+floatFromBits :: Word32 -> Float
+floatFromBits x = runST (cast x)
+
+doubleToBits :: Double -> Word64
+doubleToBits x = runST (cast x)
+
+doubleFromBits :: Word64 -> Double
+doubleFromBits x = runST (cast x)

--- a/src/Wasm/Util/Float.hs
+++ b/src/Wasm/Util/Float.hs
@@ -5,6 +5,8 @@ module Wasm.Util.Float
   , floatFromBits
   , doubleToBits
   , doubleFromBits
+  , f32CanonicalNaN
+  , f64CanonicalNaN
   ) where
 
 import Data.Array.ST (newArray, readArray, MArray, STUArray)
@@ -27,3 +29,16 @@ doubleToBits x = runST (cast x)
 
 doubleFromBits :: Word64 -> Double
 doubleFromBits x = runST (cast x)
+
+-- | In GHC 0/0 generates NaN with sign bit set (i.e. negative NaN) which is not
+-- the canonical NaN specified in the Wasm spec. This is the canonical NaN.
+f32CanonicalNaN :: Float
+f32CanonicalNaN =
+    -- 0b0_11111111_10000000000000000000000
+    floatFromBits 2143289344
+
+-- | Like `f32CanonicalNaN` but for F64.
+f64CanonicalNaN :: Double
+f64CanonicalNaN =
+    -- 0b0_11111111111_1000000000000000000000000000000000000000000000000000
+    doubleFromBits 9221120237041090560

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -24,8 +24,6 @@ main = do
               -- We aren't going to bother fully supporting
               -- Unicode function names in the reference interpreter yet.
             && "names.wast" /= file
-              -- We need more accurate floating-point support.
-            && "float_exprs.wast" /= file
         ]
 
   defaultMain $ testGroup "main"

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -25,8 +25,6 @@ main = do
               -- Unicode function names in the reference interpreter yet.
             && "names.wast" /= file
               -- We need more accurate floating-point support.
-            && "f32.wast" /= file
-            && "f64.wast" /= file
             && "f32_bitwise.wast" /= file
             && "f64_bitwise.wast" /= file
             && "float_literals.wast" /= file

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -26,7 +26,6 @@ main = do
             && "names.wast" /= file
               -- We need more accurate floating-point support.
             && "float_exprs.wast" /= file
-            && "conversions.wast" /= file
         ]
 
   defaultMain $ testGroup "main"

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -25,9 +25,6 @@ main = do
               -- Unicode function names in the reference interpreter yet.
             && "names.wast" /= file
               -- We need more accurate floating-point support.
-            && "f32_bitwise.wast" /= file
-            && "f64_bitwise.wast" /= file
-            && "float_literals.wast" /= file
             && "float_exprs.wast" /= file
             && "conversions.wast" /= file
         ]

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -12,6 +12,7 @@ import           Wasm.Text.Wast (parseWastFile)
 import           Wasm.Text.Winter (Winter)
 import           Wasm.Util.Source (Phrase)
 import           Wasm.Syntax.Values (Value (..))
+import           Wasm.Util.Float (floatToBits, doubleToBits)
 
 import           SpecTest (spectest)
 import           Wat2Wasm (wat2Wasm)
@@ -32,10 +33,14 @@ valListEq vs1 vs2 =
     length vs1 == length vs2 &&
     all (uncurry valEq) (zip vs1 vs2)
 
+-- Note: we compare float values bitwise. This is more strict than necessary:
+-- when a test expects an arithmetic NaN we can accept any of the arithmetic
+-- NaNs for the type, but this is actually easier to implement and is more
+-- deterministic too.
 valEq :: Value -> Value -> Bool
 valEq v1 v2 = case (v1, v2) of
   (I32 i1, I32 i2) -> i1 == i2
   (I64 i1, I64 i2) -> i1 == i2
-  (F32 f1, F32 f2) -> isNaN f1 && isNaN f2 || f1 == f2
-  (F64 f1, F64 f2) -> isNaN f1 && isNaN f2 || f1 == f2
+  (F32 f1, F32 f2) -> floatToBits f1 == floatToBits f2
+  (F64 f1, F64 f2) -> doubleToBits f1 == doubleToBits f2
   _ -> False

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -6,11 +6,12 @@ module Spec (tests) where
 import qualified Data.IntMap as IM
 import qualified Data.Map as M
 import           Test.Tasty (TestTree, testGroup)
-import           Test.Tasty.HUnit (testCaseSteps, assertEqual, assertFailure)
+import           Test.Tasty.HUnit (testCaseSteps, assertFailure)
 
 import           Wasm.Text.Wast (parseWastFile)
 import           Wasm.Text.Winter (Winter)
 import           Wasm.Util.Source (Phrase)
+import           Wasm.Syntax.Values (Value (..))
 
 import           SpecTest (spectest)
 import           Wat2Wasm (wat2Wasm)
@@ -24,4 +25,17 @@ tests files = testGroup "spec" $ map prep files
     parseWastFile @(Winter Phrase) @IO file input
       (M.singleton "spectest" 1)
       (IM.singleton 1 inst)
-      wat2Wasm step assertEqual assertFailure
+      wat2Wasm step valListEq assertFailure
+
+valListEq :: [Value] -> [Value] -> Bool
+valListEq vs1 vs2 =
+    length vs1 == length vs2 &&
+    all (uncurry valEq) (zip vs1 vs2)
+
+valEq :: Value -> Value -> Bool
+valEq v1 v2 = case (v1, v2) of
+  (I32 i1, I32 i2) -> i1 == i2
+  (I64 i1, I64 i2) -> i1 == i2
+  (F32 f1, F32 f2) -> isNaN f1 && isNaN f2 || f1 == f2
+  (F64 f1, F64 f2) -> isNaN f1 && isNaN f2 || f1 == f2
+  _ -> False

--- a/winter.cabal
+++ b/winter.cabal
@@ -40,8 +40,7 @@ Library
     vector (>= 0.12.1),
     primitive,
     primitive-unaligned,
-    byte-order,
-    data-binary-ieee754
+    byte-order
   Exposed-Modules:
     Wasm.Binary.Custom
     Wasm.Binary.Decode
@@ -70,6 +69,7 @@ Library
     Wasm.Util.NFData
     Wasm.Util.Show
     Wasm.Util.Source
+    Wasm.Util.Float
   HS-Source-Dirs:
     src
 

--- a/winter.cabal
+++ b/winter.cabal
@@ -40,7 +40,8 @@ Library
     vector (>= 0.12.1),
     primitive,
     primitive-unaligned,
-    byte-order
+    byte-order,
+    data-binary-ieee754
   Exposed-Modules:
     Wasm.Binary.Custom
     Wasm.Binary.Decode


### PR DESCRIPTION
This fixes floating point operations.

One notable change is Eq for Value is removed. The instance is not used in the
interpreter and should not be used in the future, because of the Float/Double
variants. A new `valEq` function is implemented to compare test outputs, which
compares floats bitwise.