### PR TITLE
Fix trapping in start function when allocating a module

### DIFF
--- a/src/Wasm/Exec/Eval.hs
+++ b/src/Wasm/Exec/Eval.hs
@@ -887,6 +887,14 @@ initialize mod names mods = do
     start_err <-
       forM (mod^.moduleStart) $ \start -> lift $ do
         f <- func inst3 start
+        -- Catch traps in "start" function and propagate those without causing
+        -- the whole initialization to fail. This is implemented differently
+        -- than the reference interpreter, but it implements the same thing. In
+        -- the reference interpreter functions have direct access to their
+        -- modules, so even if initialization fails because of a trap in "start"
+        -- the functions added to tables etc. still work. In Winter, functions
+        -- have module references, not actual module instances, so we need to
+        -- add the module to the store when "start" traps.
         catchError (invoke (IM.insert ref inst3 mods) inst3 f [] >> pure Nothing)
                    (\e -> pure (Just (show e)))
 

--- a/src/Wasm/Text/Wast.hs
+++ b/src/Wasm/Text/Wast.hs
@@ -543,6 +543,7 @@ invokeModule readModule decl k = do
           checkStateRef .= ref
           checkStateModules.at ref ?= inst
           forM_ mname $ \nm -> checkStateNames.at nm ?= ref
+          k (Right ())
 
 
 -- These tests currently do not work.

--- a/src/Wasm/Text/Wast.hs
+++ b/src/Wasm/Text/Wast.hs
@@ -84,7 +84,7 @@ class Show (Value w) => WasmEngine w m where
 
   initializeModule
     :: Module w -> Map Text ModuleRef -> IntMap (ModuleInst w m)
-    -> m (Either String (ModuleRef, ModuleInst w m))
+    -> m (Either String (ModuleRef, ModuleInst w m, Maybe String))
 
   invokeByName
     :: IntMap (ModuleInst w m) -> ModuleInst w m -> Text
@@ -521,9 +521,20 @@ invokeAction (ActionGet mname nm) k = do
 
 invokeModule
   :: forall w m. (MonadFail m, WasmEngine w m)
-  => (String -> m ByteString)                       -- convert module into Wasm binary
+  => (String -> m ByteString)
+     -- ^ Convert module into Wasm binary
   -> ModuleDecl
-  -> (Either String () -> StateT (CheckState w m) m ())
+  -> (Either String (Maybe String) -> StateT (CheckState w m) m ())
+     -- ^ Continuation. Argument is one of these:
+     --
+     -- - Left err:         Instantiation failed with "err". In this case the module
+     --                     won't be available.
+     --
+     -- - Right Nothing:    Instantiation successful, start function did not trap.
+     --
+     -- - Right (Just err): Instantiation successful, but start function
+     --                     trapped. Trapping in start function doesn't make the
+     --                     module unavailable.
   -> StateT (CheckState w m) m ()
 invokeModule readModule decl k = do
   (mname, wasm) <- case decl of
@@ -539,19 +550,11 @@ invokeModule readModule decl k = do
       case eres of
         Left err ->
           k $ Left $ "Error initializing module " ++ err
-        Right (ref, inst) -> do
+        Right (ref, inst, start_err) -> do
           checkStateRef .= ref
           checkStateModules.at ref ?= inst
           forM_ mname $ \nm -> checkStateNames.at nm ?= ref
-          k (Right ())
-
-
--- These tests currently do not work.
-ignoredFunctions :: [String]
-ignoredFunctions = [
-  -- linking.wast
-  "get table[0]"
-  ]
+          k (Right start_err)
 
 parseWastFile
   :: forall w m. (MonadFail m, MonadBaseControl IO m, WasmEngine w m)
@@ -575,11 +578,6 @@ parseWastFile path input preNames preMods readModule step valEq assertFailure =
               Right _ -> return ()
 
         CmdAssertion e -> case e of
-          AssertReturn (ActionInvoke _ nm _) _
-            | nm `elem` ignoredFunctions -> return ()
-          AssertTrap (ActionInvoke _ nm _) _
-            | nm `elem` ignoredFunctions -> return ()
-
           AssertReturn a exps -> do
             let exps' = exps^..traverse._Constant
             invokeAction a $ lift . \case
@@ -598,7 +596,8 @@ parseWastFile path input preNames preMods readModule step valEq assertFailure =
           AssertTrapModule moddecl msg ->
             invokeModule readModule moddecl $ \case
               Left _ -> return ()
-              Right _ -> lift $ assertFailure $ "Did not trap, expected " ++ msg
+              Right (Just _err) -> return ()
+              Right Nothing -> lift $ assertFailure $ "Did not trap, expected " ++ msg
 
           AssertReturnCanonicalNan _act  -> return ()
           AssertReturnArithmeticNan _act -> return ()


### PR DESCRIPTION
According to the spec, a trap in a start function does not cause module
initialization to fail (spec doesn't explicitly say that it's OK to trap
in a start function, but it also doesn't say "fail", and the last test
in "linking.wast" suggests that initialization should not fail).

Previously, when start traps, changes in memories or tables would not be
reverted, but the module would be unavailable. This is not correct
behavior, but if it was, the code would still be buggy, because if the
failing module has `elem` sections the table would have references to
functions in a non-existent module.

This patch implements trapping in start according to the spec: the
module now becomes available when start traps.