### PR TITLE
Report initialize errors as EvalError not String

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -135,7 +135,7 @@ main = do
             mods  = IntMap.singleton 1 app
         (ref, inst, mb_start_err) <- initialize ast names mods
         forM_ mb_start_err $ \start_err ->
-          liftIO (putStrLn ("start function trapped: " ++ start_err))
+          liftIO $ putStrLn $ "start function trapped: " ++ show start_err
         let name = pack func
         invokeByName (IntMap.insert ref inst mods) inst name values
       case result of

--- a/src/Wasm/Text/Winter.hs
+++ b/src/Wasm/Text/Winter.hs
@@ -11,6 +11,7 @@ module Wasm.Text.Winter where
 import           Control.Monad.Except
 import           Control.Monad.Primitive
 import           Data.Binary.Get
+import           Data.Bifunctor
 import           Data.Functor.Classes
 
 import           Wasm.Text.Wast
@@ -36,12 +37,12 @@ instance (PrimMonad m, Regioned f, Decode.Decodable f, Show1 f)
 
   decodeModule = Right . runGet Decode.getModule
   initializeModule m names mods =
-    fmap (either (Left . show) Right)
+    fmap (bimap show (\(r,i,e) -> (r, i, fmap show e)))
       $ runExceptT $ Eval.initialize m names mods
 
   invokeByName mods inst name stack =
-    fmap (either (Left . show) (Right . (,inst)))
+    fmap (bimap show (,inst))
       $ runExceptT $ Eval.invokeByName mods inst name stack
   getByName inst name  =
-    fmap (either (Left . show) (Right . (,inst)))
+    fmap (bimap show (,inst))
       $ runExceptT $ Eval.getByName inst name


### PR DESCRIPTION
this is consistent with the `EvalT` type that other errors are reported
in.